### PR TITLE
Throat the sqs.sendMessage call

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "chalk": "^2.4.2",
     "commander": "^2.19.0",
     "ramda": "^0.26.1",
-    "sqs-consumer": "^5.0.0"
+    "sqs-consumer": "^5.0.0",
+    "throat": "^4.1.0"
   },
   "devDependencies": {
     "eslint": "^5.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -824,6 +824,11 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+throat@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
+  integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
+
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"


### PR DESCRIPTION
![dilbert](https://i.pinimg.com/originals/0c/7b/fb/0c7bfb1df662d8e6b14ae0737d173dc5.gif)

As I suspected, we hit some timeout errors when redriving a very large DLQ.  I think the issue is throating the `sqs.sendMessage` call.  It's generally a good idea anyways.

## to test:
- [x] Follow the same steps as in the [previous PR](https://github.com/articulate/overdrive/pull/1).
- [x] It should still work as before, but be more limited in the concurrency department.